### PR TITLE
Runs Makred HTML through $compile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 
   "name": "angular-md",
   "description": "Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "homepage": "https://github.com/yaru22/angular-md",
   "repository": {

--- a/demo/angular-md.js
+++ b/demo/angular-md.js
@@ -1,29 +1,43 @@
+/**
+ * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
+ * @version v1.0.0 - 2015-03-19
+ * @link https://github.com/yaru22/angular-md
+ * @author Brian Park <yaru22@gmail.com>
+ * @license MIT License, http://www.opensource.org/licenses/MIT
+ */
+/* global angular, hljs, marked */
 'use strict';
-angular.module('yaru22.md', []).directive('md', function () {
-  if (typeof hljs !== 'undefined') {
-    marked.setOptions({
-      highlight: function (code, lang) {
-        if (lang) {
-          return hljs.highlight(lang, code).value;
-        } else {
-          return hljs.highlightAuto(code).value;
+angular.module('yaru22.md', []).directive('md', [
+  '$compile',
+  function ($compile) {
+    if (typeof hljs !== 'undefined') {
+      marked.setOptions({
+        highlight: function (code, lang) {
+          if (lang) {
+            return hljs.highlight(lang, code).value;
+          } else {
+            return hljs.highlightAuto(code).value;
+          }
         }
-      }
-    });
-  }
-  return {
-    restrict: 'E',
-    require: '?ngModel',
-    link: function ($scope, $elem, $attrs, ngModel) {
-      if (!ngModel) {
-        var html = marked($elem.text());
-        $elem.html(html);
-        return;
-      }
-      ngModel.$render = function () {
-        var html = marked(ngModel.$viewValue || '');
-        $elem.html(html);
-      };
+      });
     }
-  };
-});
+    return {
+      restrict: 'E',
+      require: '?ngModel',
+      link: function ($scope, $elem, $attrs, ngModel) {
+        if (!ngModel) {
+          // render transcluded text
+          var html = marked($elem.text());
+          $elem.html(html);
+          $compile($elem.contents())($scope);
+          return;
+        }
+        ngModel.$render = function () {
+          var html = marked(ngModel.$viewValue || '');
+          $elem.html(html);
+          $compile($elem.contents())($scope);
+        };
+      }  // link function
+    };
+  }
+]);

--- a/demo/angular-md.js
+++ b/demo/angular-md.js
@@ -1,6 +1,6 @@
 /**
  * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
- * @version v1.0.0 - 2015-03-19
+ * @version v1.0.1 - 2015-03-19
  * @link https://github.com/yaru22/angular-md
  * @author Brian Park <yaru22@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/dist/angular-md.js
+++ b/dist/angular-md.js
@@ -1,29 +1,43 @@
+/**
+ * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
+ * @version v1.0.0 - 2015-03-19
+ * @link https://github.com/yaru22/angular-md
+ * @author Brian Park <yaru22@gmail.com>
+ * @license MIT License, http://www.opensource.org/licenses/MIT
+ */
+/* global angular, hljs, marked */
 'use strict';
-angular.module('yaru22.md', []).directive('md', function () {
-  if (typeof hljs !== 'undefined') {
-    marked.setOptions({
-      highlight: function (code, lang) {
-        if (lang) {
-          return hljs.highlight(lang, code).value;
-        } else {
-          return hljs.highlightAuto(code).value;
+angular.module('yaru22.md', []).directive('md', [
+  '$compile',
+  function ($compile) {
+    if (typeof hljs !== 'undefined') {
+      marked.setOptions({
+        highlight: function (code, lang) {
+          if (lang) {
+            return hljs.highlight(lang, code).value;
+          } else {
+            return hljs.highlightAuto(code).value;
+          }
         }
-      }
-    });
-  }
-  return {
-    restrict: 'E',
-    require: '?ngModel',
-    link: function ($scope, $elem, $attrs, ngModel) {
-      if (!ngModel) {
-        var html = marked($elem.text());
-        $elem.html(html);
-        return;
-      }
-      ngModel.$render = function () {
-        var html = marked(ngModel.$viewValue || '');
-        $elem.html(html);
-      };
+      });
     }
-  };
-});
+    return {
+      restrict: 'E',
+      require: '?ngModel',
+      link: function ($scope, $elem, $attrs, ngModel) {
+        if (!ngModel) {
+          // render transcluded text
+          var html = marked($elem.text());
+          $elem.html(html);
+          $compile($elem.contents())($scope);
+          return;
+        }
+        ngModel.$render = function () {
+          var html = marked(ngModel.$viewValue || '');
+          $elem.html(html);
+          $compile($elem.contents())($scope);
+        };
+      }  // link function
+    };
+  }
+]);

--- a/dist/angular-md.js
+++ b/dist/angular-md.js
@@ -1,6 +1,6 @@
 /**
  * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
- * @version v1.0.0 - 2015-03-19
+ * @version v1.0.1 - 2015-03-19
  * @link https://github.com/yaru22/angular-md
  * @author Brian Park <yaru22@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/dist/angular-md.min.js
+++ b/dist/angular-md.min.js
@@ -1,6 +1,6 @@
 /**
  * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
- * @version v1.0.0 - 2015-03-19
+ * @version v1.0.1 - 2015-03-19
  * @link https://github.com/yaru22/angular-md
  * @author Brian Park <yaru22@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/dist/angular-md.min.js
+++ b/dist/angular-md.min.js
@@ -1,8 +1,8 @@
 /**
  * Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.
- * @version v1.0.0 - 2014-03-12
+ * @version v1.0.0 - 2015-03-19
  * @link https://github.com/yaru22/angular-md
  * @author Brian Park <yaru22@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
-"use strict";angular.module("yaru22.md",[]).directive("md",function(){return"undefined"!=typeof hljs&&marked.setOptions({highlight:function(a,b){return b?hljs.highlight(b,a).value:hljs.highlightAuto(a).value}}),{restrict:"E",require:"?ngModel",link:function(a,b,c,d){if(!d){var e=marked(b.text());return b.html(e),void 0}d.$render=function(){var a=marked(d.$viewValue||"");b.html(a)}}}});
+"use strict";angular.module("yaru22.md",[]).directive("md",["$compile",function(a){return"undefined"!=typeof hljs&&marked.setOptions({highlight:function(a,b){return b?hljs.highlight(b,a).value:hljs.highlightAuto(a).value}}),{restrict:"E",require:"?ngModel",link:function(b,c,d,e){if(!e){var f=marked(c.text());return c.html(f),void a(c.contents())(b)}e.$render=function(){var d=marked(e.$viewValue||"");c.html(d),a(c.contents())(b)}}}}]);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 
   "name": "angular-md",
   "description": "Angular directive to render Markdown text. It's built on blazingly fast markdown parser 'marked'.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "homepage": "https://github.com/yaru22/angular-md",
   "repository": {

--- a/src/angular-md.js
+++ b/src/angular-md.js
@@ -3,7 +3,7 @@
 'use strict';
 
 angular.module('yaru22.md', [
-]).directive('md', function () {
+]).directive('md', ['$compile', function ($compile) {
   if (typeof hljs !== 'undefined') {
     marked.setOptions({
       highlight: function (code, lang) {
@@ -24,13 +24,15 @@ angular.module('yaru22.md', [
         // render transcluded text
         var html = marked($elem.text());
         $elem.html(html);
+        $compile($elem.contents())($scope);
         return;
       }
 
       ngModel.$render = function () {
         var html = marked(ngModel.$viewValue || '');
         $elem.html(html);
+        $compile($elem.contents())($scope);
       };
     }  // link function
   };
-});
+}]);


### PR DESCRIPTION
Simply added `$compile` as a dependency and asks it to compile the Marked HTML for our apps.

This is useful when:
- Modifying Marked to return Angular UI Router-enabled links -- see ThoughtJot's example: https://github.com/roberthodgen/thought-jot/blob/a4cf7c1208b3f83350b99389bffe6cb19e57ecc9/src/static/appCtrl.js#L40

Could also be used for other directives!

Incremented version 1.0.1
